### PR TITLE
Check sidebar command visibility

### DIFF
--- a/Log Highlight.py
+++ b/Log Highlight.py
@@ -1068,6 +1068,10 @@ class LogHighlightPanelCommand(sublime_plugin.TextCommand):
 
 class LogHighlightSetAsBaseCommand(sublime_plugin.TextCommand):
 
+    def is_visible(self):
+        srch_opt = get_prefs().get('search_base', [])
+        return srch_opt.get('sidebar_enable', True)
+
     def run(self, edit, **args):
         try:
             path = args.get('paths', [])[0]

--- a/Log Highlight.sublime-settings
+++ b/Log Highlight.sublime-settings
@@ -27,7 +27,8 @@
 		// hidden folders are ignored as default, like .git, .svn
 		"ignore_dir" : [""],
 		// adjust when using network like samba
-		"max_scan_path" : 1000
+		"max_scan_path" : 1000,
+		"sidebar_enable": true
 	},
 
 	// summary panel


### PR DESCRIPTION
Current Log Highlight adds a menu item to Sidebar. My sidebar is pretty crowded already. Would be nice if we could disable that item